### PR TITLE
fix `visible`

### DIFF
--- a/metrics/Unit Price Discount Percent.yml
+++ b/metrics/Unit Price Discount Percent.yml
@@ -2,7 +2,7 @@ unique_name: Unit Price Discount Percent
 object_type: metric
 label: Unit Price Discount Percent
 calculation_method: sum
-visible: false
+is_hidden: true
 unrelated_dimensions_handling: empty
 dataset: Reseller Sales
 column: unitpricediscountpct


### PR DESCRIPTION
Shouldn't this be [is_hidden](https://github.com/semanticdatalayer/SML/blob/main/sml-reference/metric.md#is_hidden)? I can't see a `visible` property in the spec but I have found other similar examples of undocumented attributes. This one however does appear to have an equivalent.